### PR TITLE
fixed OpenBMC data paths

### DIFF
--- a/redDrumObmcMain.py
+++ b/redDrumObmcMain.py
@@ -114,13 +114,23 @@ def redDrumMain(rdHost="127.0.0.1", rdPort=5001, isLocal=False, debug=False, rdS
     #
 
     # ***********************************
-    # *** EDIT THIS TO PUT THE " RedDrum-Frontend " package in the Python Path:
-    # ******** for now, we will add a path to ../RedDrum-Frontend  
+    # *** YOU MUST HAVE THE "reddrum_frontend" package from  RedDrum-Frontend in your Python Path:
     cwd=os.getcwd()
-    defaultFrontendPath=os.path.abspath(os.path.join(cwd,"..","RedDrum-Frontend"))
-    sys.path.append(defaultFrontendPath)
+    # reddrum_frontend should be in the python path
+    # see RedDrum-Frontend README.md for how to install it so that it shows up in the python path under site packages
+    #   for development, clone the Frontend and import with with -e option to allow editing 
+    #     clone https://github.com/RedDrum-Redfish-Project/RedDrum-Frontend
+    #     pip install -e ./RedDrum-Frontend
+    #   If no need to edit the Frontend code--just install the frontend into sitepackages
+    #     pip install git+https://github.com/RedDrum-Redfish-Project/RedDrum-Frontend.git
+    #
+    # to hard code the python-path to a dev RedDrum-Frontend
+    #     defaultFrontendPath=os.path.abspath(os.path.join(cwd,"---joint path over to the repo---","RedDrum-Frontend"))
+    #     sys.path.append(defaultFrontendPath) # add this to the path
+    #     from reddrum_frontend import RdRootData
+    #
     # *** end create path to the Frontend
-    # ***********************************
+    # **************************************
 
     # now import the FrontEnd
     from reddrum_frontend import RdRootData   # import the RedDrum Root Data Structure and logMsg Method
@@ -128,7 +138,8 @@ def redDrumMain(rdHost="127.0.0.1", rdPort=5001, isLocal=False, debug=False, rdS
 
     # now calculate the directory path to the FrontEnd Package Directory which has /reddrum_frontend 
     # this works even if the Frontend package above was put in site-packages
-    rdr.frontEndDirPath=os.path.abspath(os.path.join(os.path.dirname( inspect.getfile(RdRootData)), ".."))
+    rdr.frontEndPkgPath=os.path.dirname( inspect.getfile(RdRootData)) # return the path to reddrum_frontend
+    rdr.frontEndDirPath=os.path.abspath(os.path.join(rdr.frontEndPkgPath, ".."))
     #print("EEEEEEEEEEEEEEEE DIR: frontend dir: {}".format(rdr.frontEndDirPath))
 
     # initialize root data with passed-in args
@@ -149,8 +160,13 @@ def redDrumMain(rdHost="127.0.0.1", rdPort=5001, isLocal=False, debug=False, rdS
     # if you want to create your own, copy the front-end of the RdLogger code and then import your own
     # if you don't set rdr.logger=RdLogger() or your custom logger, then messages are not logged
     loggerName="None"
-    if rdr.isLocal is not True:     
-        from RedfishService import RdLogger         # import the default RedDrum logger
+
+    # set a property to indicate whether to startup a syslog logger for RedDrum
+    # if startObmcLogger is True, it will try to create a logger,
+    startObmcLogger=False     # **** if False, we wont try to start a logger with OpenBMC
+    
+    if rdr.isLocal is not True and startObmcLogger is True:     
+        from reddrum_frontend import RdLogger         # import the default RedDrum logger
         rdr.rdLogger = RdLogger(rdr.rdServiceName)   # dflt rdLogger=None
         loggerName="RdLogger"
 

--- a/reddrum_openbmc/backendRoot.py
+++ b/reddrum_openbmc/backendRoot.py
@@ -6,6 +6,7 @@
 # Backend root class for OpenBMC
 import os
 import json
+import inspect
 from .chassisBackend   import RdChassisBackend
 from .managersBackend  import RdManagersBackend
 from .systemsBackend   import RdSystemsBackend
@@ -34,18 +35,37 @@ class RdBackendRoot():
         self.backendStatus=1
         return(0)
 
+
     def startup(self,rdr):
         # set the data paths for OpenBMC 
         rdSvcPath=os.getcwd()
-        rdr.baseDataPath=os.path.join(rdSvcPath, "reddrum_frontend", "Data")
+
+        #rdr.baseDataPath=os.path.join(rdSvcPath, "reddrum_frontend", "Data")
+        # note:  rdr.frontEndDirPath is the path to  reddrum_frontend
+        rdr.baseDataPath=os.path.join(rdr.frontEndPkgPath,"Data")
+        print("EEEEEEEE: baseDataPath: {}".format(rdr.baseDataPath))
 
         # xg44 FIX final paths for OpenBMC /var and /etc...
-        rdr.varDataPath="/var/www/rf"
-        rdr.RedDrumConfPath=os.path.join(rdSvcPath, "RedDrum.conf" )
-        rdr.schemasPath = os.path.join(rdSvcPath, "schemas")
+        rdr.varDataPath=os.path.join("/var", "www", "rf")
+        print("EEEEEEEE: varDataPath: {}".format(rdr.varDataPath))
+
+        # if we have a RedDrum.conf file in etc/ use it. otherwise use the default
+        #rdr.RedDrumConfPath=os.path.join(rdSvcPath, "RedDrum.conf" )
+        redDrumConfPathEtc=os.path.join("/etc",  "RedDrum.conf" )
+        redDrumConfPathFrontend=os.path.join(rdr.frontEndPkgPath, "RedDrum.conf")
+        if os.path.isfile(redDrumConfPathEtc):
+            rdr.RedDrumConfPath=redDrumConfPathEtc
+        else:
+            rdr.RedDrumConfPath=redDrumConfPathFrontend
+        print("EEEEEEEE: RedDrumConfPath: {}".format(rdr.RedDrumConfPath))
+
+        # set path to schemas -- not used now
+        rdr.schemasPath = os.path.join(rdSvcPath, "schemas") #not used now
 
         # set path to bash scripts to run to get data from Linux
-        self.obmcScriptsPath = os.path.join(rdSvcPath, "reddrum_openbmc" )
+        #self.obmcScriptsPath = os.path.join(rdSvcPath, "reddrum_openbmc" )
+        self.obmcScriptsPath = os.path.dirname( inspect.getfile(RdBackendRoot))
+        print("EEEEEEEE: obmcScriptsPath: {}".format(self.obmcScriptsPath))
 
         # not that syslog logging is enabled on OpenBMC by default unless -L (isLocal) option was specified
         # turn-on console messages also however

--- a/runRedDrum
+++ b/runRedDrum
@@ -1,5 +1,0 @@
-#!/bin/bash
-./clearCaches
-cd ..
-python3.4 redDrumMain.py -L 
-

--- a/scripts/redDrumObmcMain
+++ b/scripts/redDrumObmcMain
@@ -114,13 +114,23 @@ def redDrumMain(rdHost="127.0.0.1", rdPort=5001, isLocal=False, debug=False, rdS
     #
 
     # ***********************************
-    # *** EDIT THIS TO PUT THE " RedDrum-Frontend " package in the Python Path:
-    # ******** for now, we will add a path to ../RedDrum-Frontend  
+    # *** YOU MUST HAVE THE "reddrum_frontend" package from  RedDrum-Frontend in your Python Path:
     cwd=os.getcwd()
-    defaultFrontendPath=os.path.abspath(os.path.join(cwd,"..","RedDrum-Frontend"))
-    sys.path.append(defaultFrontendPath)
+    # reddrum_frontend should be in the python path
+    # see RedDrum-Frontend README.md for how to install it so that it shows up in the python path under site packages
+    #   for development, clone the Frontend and import with with -e option to allow editing 
+    #     clone https://github.com/RedDrum-Redfish-Project/RedDrum-Frontend
+    #     pip install -e ./RedDrum-Frontend
+    #   If no need to edit the Frontend code--just install the frontend into sitepackages
+    #     pip install git+https://github.com/RedDrum-Redfish-Project/RedDrum-Frontend.git
+    #
+    # to hard code the python-path to a dev RedDrum-Frontend
+    #     defaultFrontendPath=os.path.abspath(os.path.join(cwd,"---joint path over to the repo---","RedDrum-Frontend"))
+    #     sys.path.append(defaultFrontendPath) # add this to the path
+    #     from reddrum_frontend import RdRootData
+    #
     # *** end create path to the Frontend
-    # ***********************************
+    # **************************************
 
     # now import the FrontEnd
     from reddrum_frontend import RdRootData   # import the RedDrum Root Data Structure and logMsg Method
@@ -128,7 +138,8 @@ def redDrumMain(rdHost="127.0.0.1", rdPort=5001, isLocal=False, debug=False, rdS
 
     # now calculate the directory path to the FrontEnd Package Directory which has /reddrum_frontend 
     # this works even if the Frontend package above was put in site-packages
-    rdr.frontEndDirPath=os.path.abspath(os.path.join(os.path.dirname( inspect.getfile(RdRootData)), ".."))
+    rdr.frontEndPkgPath=os.path.dirname( inspect.getfile(RdRootData)) # return the path to reddrum_frontend
+    rdr.frontEndDirPath=os.path.abspath(os.path.join(rdr.frontEndPkgPath, ".."))
     #print("EEEEEEEEEEEEEEEE DIR: frontend dir: {}".format(rdr.frontEndDirPath))
 
     # initialize root data with passed-in args
@@ -149,8 +160,13 @@ def redDrumMain(rdHost="127.0.0.1", rdPort=5001, isLocal=False, debug=False, rdS
     # if you want to create your own, copy the front-end of the RdLogger code and then import your own
     # if you don't set rdr.logger=RdLogger() or your custom logger, then messages are not logged
     loggerName="None"
-    if rdr.isLocal is not True:     
-        from RedfishService import RdLogger         # import the default RedDrum logger
+
+    # set a property to indicate whether to startup a syslog logger for RedDrum
+    # if startObmcLogger is True, it will try to create a logger,
+    startObmcLogger=False     # **** if False, we wont try to start a logger with OpenBMC
+    
+    if rdr.isLocal is not True and startObmcLogger is True:     
+        from reddrum_frontend import RdLogger         # import the default RedDrum logger
         rdr.rdLogger = RdLogger(rdr.rdServiceName)   # dflt rdLogger=None
         loggerName="RdLogger"
 

--- a/scripts/runRedDrum
+++ b/scripts/runRedDrum
@@ -1,5 +1,5 @@
 #!/bin/bash
 ./clearCaches
 cd ..
-python3.4 redDrumObmcMain.py -L 
+python3 redDrumObmcMain.py 
 

--- a/scripts/runRedDrumStubs
+++ b/scripts/runRedDrumStubs
@@ -1,5 +1,6 @@
 #!/bin/bash
 ./clearCaches
 cd ..
-python3.4 redDrumObmcMain.py -L --EnableBackendStubs
+#python3 redDrumObmcMain.py -L --EnableBackendStubs
+python3 redDrumObmcMain.py  --EnableBackendStubs
 


### PR DESCRIPTION
changes to support proper data paths in open BMC
1) made run scripts use python3  (vs python3.4)
2) calculating the path to the Frontend and using that to construct paths inside that package
3) calculating the path to the reddrum_openbmc backend pkg and using that for paths to scripts in backend
4) calculating path to RedDrum.conf by:
     --- first checking to see if there is a RedDrum.conf in /etc  ---and if so using that path
     --- then if no /etc/RedDrum.conf path, it uses the default RedDrum.conf in the frontend package
    (so no need to copy RedDrum.conf to etc to make it work)
5. created a property so its easy to not start the Logger for openBmc.  So its turned-off for now
    But I found the problem causing the exception and fixed it.   so we can test tomorrow.
6. reddrum_openbmc is NOW EXPECTING  that we have a reddrum_frontend in site-packages.
7. changed scripts runRedDrumStubs to not use -L so it is close to same code paths as real code