### PR TITLE
fix openBMC issues not running .sh scripts to for manager ip info

### DIFF
--- a/reddrum_openbmc/getObmcProtocolInfo.sh
+++ b/reddrum_openbmc/getObmcProtocolInfo.sh
@@ -6,7 +6,8 @@
 debug="$1"
 
 # get the route info and extract the devicename and gateway from the route info
-netstatinfo=`netstat -tlp`
+#netstatinfo=`netstat -tlp`
+netstatinfo=`netstat -tl`
 mysshPort=`echo "${netstatinfo}" | awk '/ssh/ {print $4; exit }'`
 myhttpPort=`echo "${netstatinfo}" | awk '/http/ {print $4; exit }'`
 myhttpsPort=`echo "${netstatinfo}" | awk '/https/ {print $4; exit }'`

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(name='RedDrum-OpenBMC',
       download_url='https://github.com/RedDrum-Redfish-Project/RedDrum-OpenBMC/archive/0.9.5.tar.gz',
       packages=['reddrum_openbmc'],
       scripts=['scripts/redDrumObmcMain'],
+      package_data={'reddrum_openbmc': ['getObmcIpInfo.sh','getObmcProtocolInfo.sh'] },
       install_requires=[
           'RedDrum-Frontend==0.9.5', # the common RedDrum Frontend code that has dependency on Flask
           'passlib==1.7.1',          # used by Frontend


### PR DESCRIPTION
1. fixed setup.py to include the two bash scripts that are called to get linux network info as package_data
2. changed one script to not use the -p option in netstat since openbmc uses busybox and it doesn't support that option.   script run fine w/o it.