### PR TITLE
fixes for JsonSchemaValidator to be clean

### DIFF
--- a/reddrum_openbmc/getObmcIpInfo.sh
+++ b/reddrum_openbmc/getObmcIpInfo.sh
@@ -73,8 +73,19 @@ fi
 
 devPath="/sys/class/net/"${dev}"/"
 speed=`cat ${devPath}speed`
-mac=`cat  ${devPath}address`
+if [ "${speed}" = "" ]; then
+    speed="null"
+fi
+macraw=`cat  ${devPath}address`
+if [ "${macraw}" = "" ]; then
+    mac="null"
+else
+    mac="\"null\""
+fi
 duplex=`cat  ${devPath}duplex`       # full or half
+if [ "${duplex}" = "" ]; then
+    duplex="null"
+fi
 operstate=`cat  ${devPath}operstate` # up or down
 if [ "${duplex}" = "full" ]; then
     isfullduplex="true"
@@ -99,11 +110,11 @@ echo "{"
 echo "    \"Device\": " "\"${dev}\","
 echo "    \"Name\": " "\"${dev}\","
 echo "    \"Id\": " "\"${id}\","
-echo "    \"SpeedMbps\": " "\"${speed}\","
+echo "    \"SpeedMbps\": " "${speed},"
 echo "    \"InterfaceEnabled\": " "${isinterfaceEnabled},"
 echo "    \"EthDevice\": " "\"${dev}\","
-echo "    \"MACAddress\": " "\"${mac}\","
-echo "    \"PermanentMACAddress\": " "\"${mac}\","
+echo "    \"MACAddress\": " "${mac},"
+echo "    \"PermanentMACAddress\": " "${mac},"
 echo "    \"IPV4Address\": " "\"${ipv4Address}\","
 echo "    \"IPV6Address\": " "\"${ipv6Address}\","
 echo "    \"IPV4Origin\": " "\"${v4Mode}\","

--- a/reddrum_openbmc/getObmcProtocolInfo.sh
+++ b/reddrum_openbmc/getObmcProtocolInfo.sh
@@ -15,22 +15,22 @@ myeePort=`echo "${netstatinfo}" | awk '/ee/ {print $4; exit }'`
 myhostname=`hostname`
 myfqdn=`hostname -f`
 
-sshEnabled="False"
-httpEnabled="False"
-httpsEnabled="False"
-eeEnabled="False"
+sshEnabled="false"
+httpEnabled="false"
+httpsEnabled="false"
+eeEnabled="false"
 
 if [ "${mysshPort}" != "" ]; then
-    sshEnabled="True"
+    sshEnabled="true"
 fi
 if [ "${myhttpPort}" != "" ]; then
-    httpEnabled="True"
+    httpEnabled="true"
 fi
 if [ "${myhttpsPort}" != "" ]; then
-    httpsEnabled="True"
+    httpsEnabled="true"
 fi
 if [ "${myeePort}" != "" ]; then
-    eeEnabled="True"
+    eeEnabled="true"
 fi
 
 if [ "${debug}" == "debug" ]; then
@@ -48,9 +48,9 @@ if [ "${debug}" == "debug" ]; then
 fi
 
 echo "{"
-echo "    \"SSH\":   { \"ProtocolEnabled\": " "\"${sshEnabled}\" },"
-echo "    \"HTTP\":  { \"ProtocolEnabled\": " "\"${httpEnabled}\" },"
-echo "    \"HTTPS\": { \"ProtocolEnabled\": " "\"${httpsEnabled}\" },"
+echo "    \"SSH\":   { \"ProtocolEnabled\": " "${sshEnabled} },"
+echo "    \"HTTP\":  { \"ProtocolEnabled\": " "${httpEnabled} },"
+echo "    \"HTTPS\": { \"ProtocolEnabled\": " "${httpsEnabled} },"
 echo "    \"HostName\": " "\"${myhostname}\","
 echo "    \"FQDN\": " "\"${myfqdn}\""
 echo "}"

--- a/reddrum_openbmc/obmcDbusInterfaces.py
+++ b/reddrum_openbmc/obmcDbusInterfaces.py
@@ -31,7 +31,7 @@ class RdOpenBmcDbusInterfaces():
         resp=dict()
         # get the properties
         if( self.stub is True):
-            resp["FirmwareVersion"]="0.9.0x"   # a string indicating the obmc FW version
+            resp["FirmwareVersion"]="0.9.9"   # a string indicating the obmc FW version
         else:
             resp["FirmwareVersion"]=self.ProcDbus.get_bmc_fw_ver()   # a string indicating the obmc FW version
 
@@ -114,7 +114,7 @@ class RdOpenBmcDbusInterfaces():
     #        where <assetTag> is a string
     def getObmcAssetTag(self):
         if( self.stub is True):
-            resp="MyASSETTAGx"
+            resp="OCPLab1"
         else:
             resp=self.ProcDbus.get_chassis_asset_tag()
         return(resp)

--- a/reddrum_openbmc/obmcDiscovery.py
+++ b/reddrum_openbmc/obmcDiscovery.py
@@ -213,7 +213,8 @@ class RdOpenBmcDiscovery():
                                 "ConnectTypesSupported": self.staticCfg.commandShellConnectTypesSupported }
 
         resp["ActionsResetAllowableValues"]=["GracefulRestart","ForceRestart"]
-        resp["BaseNavigationProperties"]=["NetworkProtocol","EthernetInterfaces","LogServices"] # required in BaseServerProfile
+        #resp["BaseNavigationProperties"]=["NetworkProtocol","EthernetInterfaces","LogServices"] # required in BaseServerProfile
+        resp["BaseNavigationProperties"]=["NetworkProtocol","EthernetInterfaces"] # required in BaseServerProfile
 
         resp["GetDateTimeFromOS"]=True
         resp["GetServiceEntryPointUuidFrom"]="ServiceRoot"   # ServiceRoot | UUID 
@@ -344,7 +345,7 @@ class RdOpenBmcDiscovery():
         if "Board" in tempSensorInfo["Id"]:
             resp["Id"]["Board"]={}
             resp["Id"]["Board"]["Name"] = "Board Temp"
-            resp["Id"]["Board"]["PhysicalContext"] = "Board"
+            resp["Id"]["Board"]["PhysicalContext"] = "SystemBoard"
             resp["Id"]["Board"]["Volatile"] = [ "ReadingCelsius" ]
             resp["Id"]["Board"]["AddRelatedItems"] = ["System","Chassis"]
             resp["Id"]["Intake"]["Status"] =  {"State": "Enabled", "Health": "OK" }

--- a/reddrum_openbmc/obmcLinuxInterfaces.py
+++ b/reddrum_openbmc/obmcLinuxInterfaces.py
@@ -36,7 +36,8 @@ class RdOpenBmcLinuxInterfaces():
     def getObmcNetworkProtocolInfo(self):
         exitcode = 500
         protoInfo={}
-        return(exitcode,protoInfo)
+        if self.rdr.enableBackendStubs is not True:
+            return(exitcode,ipInfo)
         scriptPath = os.path.join(self.rdr.backend.obmcScriptsPath, "getObmcProtocolInfo.sh")
         arg1 = "arg1" # current script doesn't require arg but showing here if we need to add
         arg2 = "arg2" # 
@@ -63,7 +64,8 @@ class RdOpenBmcLinuxInterfaces():
     def getObmcIpInfo(self,device):
         exitcode = 500
         ipInfo={}
-        return(exitcode,ipInfo)
+        if self.rdr.enableBackendStubs is not True:
+            return(exitcode,ipInfo)
         scriptPath = os.path.join(self.rdr.backend.obmcScriptsPath, "getObmcIpInfo.sh")
         arg1 = device # the "device" Name to use in the response
         arg2 = "arg2" # 
@@ -86,8 +88,7 @@ class RdOpenBmcLinuxInterfaces():
         #  }
         #  load to a json struct
         getObmcIpInfoOutputString = str(out, encoding='UTF-8')   # convert from bytes to utf8 string. 
-        print("EEEEEEEEEEE")
-        print(" ipinfo: {}".format(getObmcIpInfoOutputString))
+        print("DEBUG:  ipinfo: {}".format(getObmcIpInfoOutputString))
         backendGetIpInfo=json.loads(getObmcIpInfoOutputString )
 
 


### PR DESCRIPTION
several fixes to pass all JsonSChemaResponseValidator tests.
1-in Thermal, changed physical context to SystemBoard instead of Board
2-corrected some bad json in the Manager NetworkProtocol and Ethernet response from the bash shell
3-cleaned up some stub data
4-added if stub test so that when running with stubs we will get IP info from the system instead of failing the uri