### PR TITLE
re-align oemFrontendUtils with frontend

### DIFF
--- a/reddrum_openbmc/backendRoot.py
+++ b/reddrum_openbmc/backendRoot.py
@@ -12,7 +12,7 @@ from .managersBackend  import RdManagersBackend
 from .systemsBackend   import RdSystemsBackend
 
 from .obmcDiscovery    import RdOpenBmcDiscovery
-from .oemFrontendUtils import DellESI_FrontendOemUtils
+from .oemFrontendUtils import FrontendOemUtils
 
 
 class RdBackendRoot():
@@ -21,7 +21,7 @@ class RdBackendRoot():
         self.version = "0.9"
         self.backendStatus=0
         self.discoveryState = 0
-        self.oemUtils=DellESI_FrontendOemUtils(rdr)
+        self.oemUtils=FrontendOemUtils(rdr)
         self.rdBeIdConstructionRule = "Monolythic"
         #   valid rdBeIdConstructionRule values are:  "Monolythic", "Dss9000", "Aggregator"
 

--- a/reddrum_openbmc/oemFrontendUtils.py
+++ b/reddrum_openbmc/oemFrontendUtils.py
@@ -11,25 +11,34 @@
 
 import re
 
-class DellESI_FrontendOemUtils():
+class FrontendOemUtils():
     def __init__(self,rdr):
         self.rdr=rdr
+        self.dellEsiUtils=self.DellESI_FrontendOemUtils(rdr)
+        # enter other company/group oem utilities here
 
-    def rsdLocation(self, chassid):
-        idRule = self.rdr.backend.rdBeIdConstructionRule
-        #   valid rdBeIdConstructionRule values are:  "Monolythic", "Dss9000", "Aggregator"
-        chas=None
-        rid=None
-        if(idRule=="Dss9000"):
-            pass
-        elif (idRule=="Monolythic"):
-            rid=chassid
-            parent=None
-        elif (idRule=="Aggregator"):
-            rid=chassid
-            parent=None
-            if chassid in self.rdr.root.chassis.chassisDb:
-                if "ContainedBy" in self.rdr.root.chassis.chassisDb[chassid]:
-                    parent = self.rdr.root.chassis.chassisDb[chassid]["ContainedBy"]
-        return( rid, parent)
+
+    class DellESI_FrontendOemUtils():
+        def __init__(self,rdr):
+            self.rdr=rdr
+
+        def rsdLocation(self, chassid):
+            idRule = self.rdr.backend.rdBeIdConstructionRule
+            #   valid rdBeIdConstructionRule values are:  "Monolythic", "Dss9000", "Aggregator"
+            chas=None
+            rid=None
+            if(idRule=="Dss9000"):
+                pass
+            elif (idRule=="Monolythic"):
+                rid=chassid
+                parent=None
+            elif (idRule=="Aggregator"):
+                rid=chassid
+                parent=None
+                if chassid in self.rdr.root.chassis.chassisDb:
+                    if "ContainedBy" in self.rdr.root.chassis.chassisDb[chassid]:
+                        parent = self.rdr.root.chassis.chassisDb[chassid]["ContainedBy"]
+            return( rid, parent)
+
+    # create class for other oem utils here
 


### PR DESCRIPTION
RedDrum-Frontend now calls the DellESI oem utils as a sub-class of OemUtils class.
aligning with that